### PR TITLE
Add confirmation field in contact request

### DIFF
--- a/src/Form/Extension/ContactTypeExtension.php
+++ b/src/Form/Extension/ContactTypeExtension.php
@@ -16,6 +16,7 @@ namespace MonsieurBiz\SyliusContactRequestPlugin\Form\Extension;
 use MonsieurBiz\SyliusSettingsPlugin\Provider\SettingsProviderInterface;
 use Sylius\Bundle\CoreBundle\Form\Type\ContactType;
 use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TelType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -28,6 +29,9 @@ final class ContactTypeExtension extends AbstractTypeExtension
     ) {
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
@@ -62,6 +66,22 @@ final class ContactTypeExtension extends AbstractTypeExtension
                 'constraints' => $isPhoneNumberRequired ? $requiredConstraints : $defaultConstraints,
             ])
         ;
+
+        $isConfirmationFieldDisplayed = (bool) $this->settingProvider->getSettingValue('monsieurbiz_contact_request.contact', 'field_confirmation_displayed');
+        if ($isConfirmationFieldDisplayed) {
+            $confirmationFieldLabel = (string) $this->settingProvider->getSettingValue('monsieurbiz_contact_request.contact', 'field_confirmation_label');
+            $confirmationFieldLabel = empty($confirmationFieldLabel) ? 'monsieurbiz.contact_request.form.confirmation_default_label' : $confirmationFieldLabel;
+            $builder->add('confirmation', CheckboxType::class, [
+                'label' => $confirmationFieldLabel,
+                'label_html' => true,
+                'required' => true,
+                'constraints' => [
+                    new Assert\NotBlank([
+                        'message' => 'monsieurbiz.contact_request.confirmation_error',
+                    ]),
+                ],
+            ]);
+        }
     }
 
     public static function getExtendedTypes(): iterable

--- a/src/Form/Type/ContactSettingsType.php
+++ b/src/Form/Type/ContactSettingsType.php
@@ -17,6 +17,7 @@ use MonsieurBiz\SyliusRichEditorPlugin\Form\Type\RichEditorType;
 use MonsieurBiz\SyliusSettingsPlugin\Form\AbstractSettingsType;
 use MonsieurBiz\SyliusSettingsPlugin\Form\SettingsTypeInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -117,6 +118,24 @@ final class ContactSettingsType extends AbstractSettingsType implements Settings
             CheckboxType::class,
             [
                 'label' => 'monsieurbiz.contact_request.settings.field_phone_number_required',
+                'required' => false,
+            ]
+        );
+        $this->addWithDefaultCheckbox(
+            $builder,
+            'field_confirmation_displayed',
+            CheckboxType::class,
+            [
+                'label' => 'monsieurbiz.contact_request.settings.field_confirmation_displayed',
+                'required' => false,
+            ]
+        );
+        $this->addWithDefaultCheckbox(
+            $builder,
+            'field_confirmation_label',
+            TextareaType::class,
+            [
+                'label' => 'monsieurbiz.contact_request.settings.field_confirmation_label',
                 'required' => false,
             ]
         );

--- a/src/Resources/config/monsieurbiz/settings.yaml
+++ b/src/Resources/config/monsieurbiz/settings.yaml
@@ -15,3 +15,4 @@ monsieurbiz_sylius_settings:
                 field_company_required: false
                 field_phone_number_displayed: true
                 field_phone_number_required: false
+                field_confirmation_displayed: false

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -21,6 +21,7 @@ monsieurbiz:
             name: 'Name'
             company: 'Company'
             phone_number: 'Phone number'
+            confirmation_default_label: 'By using this form, you consent to our collection, use and disclosure of your personal information for purposes related to your request.'
         settings:
             plugin_name: 'Contact page'
             description: 'Configure the contact page'
@@ -30,6 +31,8 @@ monsieurbiz:
             field_company_required: 'The company field is required'
             field_phone_number_displayed: 'Display the phone field'
             field_phone_number_required: 'The phone field is required'
+            field_confirmation_displayed: 'Display the confirmation field'
+            field_confirmation_label : 'Confirmation field label'
 
 monsieurbiz_menu:
     provider:

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -21,6 +21,7 @@ monsieurbiz:
             name: 'Nom'
             company: 'Entreprise'
             phone_number: 'Numéro de téléphone'
+            confirmation_default_label: 'En utilisant ce formulaire, vous acceptez à ce que nous recueillions, utilisions et divulguions vos renseignements personnels à des fins liées à votre demande.'
         settings:
             plugin_name: 'Page de contact'
             description: 'Configurer la page de contact'
@@ -30,6 +31,8 @@ monsieurbiz:
             field_company_required: 'Le champ entreprise est requis'
             field_phone_number_displayed: 'Afficher le champ téléphone'
             field_phone_number_required: 'Le champ téléphone est requis'
+            field_confirmation_displayed: 'Afficher le champ de confirmation de l''envoi'
+            field_confirmation_label : 'Libellé du champ de confirmation de l''envoi'
 monsieurbiz_menu:
     provider:
         contact: 'Page de contact'

--- a/src/Resources/translations/validators.en.yaml
+++ b/src/Resources/translations/validators.en.yaml
@@ -1,0 +1,3 @@
+monsieurbiz:
+    contact_request:
+        confirmation_error: 'You need to approve this field'

--- a/src/Resources/translations/validators.fr.yaml
+++ b/src/Resources/translations/validators.fr.yaml
@@ -1,0 +1,3 @@
+monsieurbiz:
+    contact_request:
+        confirmation_error: 'Vous devez donner approuver ce champ'

--- a/src/Resources/views/Shop/ContactRequest/request.html.twig
+++ b/src/Resources/views/Shop/ContactRequest/request.html.twig
@@ -60,6 +60,10 @@
 
                 {{ form_row(form.message, sylius_test_form_attribute('contact-message')) }}
 
+                {% if setting('monsieurbiz_contact_request.contact', 'field_confirmation_displayed')|default(false) %}
+                    {{ form_row(form.confirmation) }}
+                {% endif %}
+
                 {{ sylius_template_event('sylius.shop.contact.request.form', {'form': form}) }}
 
                 {{ form_row(form._token) }}


### PR DESCRIPTION
## Default values

### Settings

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/9284fb5e-57e8-45e9-8a87-036f9c539d97" />

### Form

<img width="808" alt="image" src="https://github.com/user-attachments/assets/346cd244-d7e7-4d65-bd39-cf6944150cf3" />

## No label

### Settings
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/cdb9145c-aa87-4396-9b36-013547e7193d" />

### Form
<img width="776" alt="image" src="https://github.com/user-attachments/assets/da0fadbd-f3c9-44cc-8a63-b17a2116931e" />

### Validation

<img width="798" alt="image" src="https://github.com/user-attachments/assets/59d9a56a-8339-40ba-aad3-0423753659b3" />
<img width="1444" alt="image" src="https://github.com/user-attachments/assets/6a7ec250-5e9d-4bd1-9526-f66a79b0268f" />


## With label

### Settings

You can put markup if you want

<img width="1099" alt="image" src="https://github.com/user-attachments/assets/66939ba7-1850-47dc-a5b7-bef8f123a9b6" />

### Form

<img width="783" alt="image" src="https://github.com/user-attachments/assets/0ddb84f6-9f8c-495e-9226-6621db82f8b2" />

### Validation

<img width="735" alt="image" src="https://github.com/user-attachments/assets/dd2fc086-8a50-4140-9e27-eef0bdc2d6c2" />
<img width="1444" alt="image" src="https://github.com/user-attachments/assets/d60ce219-334c-44ac-9323-0146b1b1d89b" />

