### PR TITLE
TASK: add missing icon for menu plugin target modal

### DIFF
--- a/src/Menu/ContactUrlProvider.php
+++ b/src/Menu/ContactUrlProvider.php
@@ -23,7 +23,7 @@ class ContactUrlProvider extends AbstractUrlProvider
 
     protected string $code = self::PROVIDER_CODE;
 
-    protected string $icon = 'phone';
+    protected string $icon = 'tabler:phone';
 
     protected int $priority = 900;
 


### PR DESCRIPTION
**Description**

I noticed that there was no icon. So i added one 🙂:

<img width="503" height="55" alt="sylius_menu_plugin_choose_modal_contact_page" src="https://github.com/user-attachments/assets/0151fcea-ceea-4152-b505-f90f794e80ec" />
